### PR TITLE
Key length refactor

### DIFF
--- a/lib/date_shift_generator.rb
+++ b/lib/date_shift_generator.rb
@@ -1,10 +1,14 @@
 require_relative 'shift_generator'
 
 class DateShiftGenerator < ShiftGenerator
-  KEY_LENGTH = 6
+
+  def initialize(key_input)
+    super(key_input)
+    @key_length = 6
+  end
 
   def shift_array
-    key_squared = @key.to_i ** 2
+    key_squared = validate_key_input.to_i ** 2
     last_digits = key_squared.to_s[(-1 * SHIFT_COUNT)..-1]
     last_digits.chars.map {|character| character.to_i}
   end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -7,7 +7,7 @@ class Enigma
   def random_key
     max_number = "9" * (ShiftGenerator::SHIFT_COUNT + 1)
     random_number_string = rand(max_number.to_i).to_s
-    format = '%' + KeyShiftGenerator.new(0).key_length.to_s + 's'
+    format = KeyShiftGenerator.new(0).format
     (format % random_number_string).gsub(" ", "0")
   end
 

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -54,6 +54,8 @@ class Enigma
         require "pry"; binding.pry
       end
     end
-    decrypt(ciphertext, KeyShiftGenerator.new(key_guess - 1).key, date)
+    formatted_key = KeyShiftGenerator.new(key_guess - 1).validate_key_input
+    formatted_date = DateShiftGenerator.new(date).validate_key_input
+    decrypt(ciphertext, formatted_key, formatted_date)
   end
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -7,8 +7,8 @@ class Enigma
   def random_key
     max_number = "9" * (ShiftGenerator::SHIFT_COUNT + 1)
     random_number_string = rand(max_number.to_i).to_s
-    ('%5s' % random_number_string).gsub(" ", "0")
-    # TO DO: ^ figure out how to change 5 to SHIFT_COUNT + 1
+    format = '%' + KeyShiftGenerator.new(0).key_length.to_s + 's'
+    (format % random_number_string).gsub(" ", "0")
   end
 
   def todays_date

--- a/lib/key_shift_generator.rb
+++ b/lib/key_shift_generator.rb
@@ -1,12 +1,14 @@
 require_relative 'shift_generator'
 
 class KeyShiftGenerator < ShiftGenerator
-  KEY_LENGTH = SHIFT_COUNT + 1
-  # TO DO: ^ change key_length to an ivar (in ShiftGenerator & DateShiftGenerator too). Also stop validating key input in initialize.
+  def initialize(key_input)
+    super(key_input)
+    @key_length = SHIFT_COUNT + 1
+  end
 
   def shift_array
     key_shifts = []
-    @key.chars.each_cons(2) do |number1, number2|
+    validate_key_input.chars.each_cons(2) do |number1, number2|
       key_shifts << (number1 + number2).to_i
     end
     key_shifts

--- a/lib/shift_generator.rb
+++ b/lib/shift_generator.rb
@@ -1,22 +1,21 @@
 class ShiftGenerator
   SHIFT_COUNT = 4
-  KEY_LENGTH = 7
 
-  attr_reader :key_input, :formatted_key
+  attr_reader :key_input, :key_length, :formatted_key
 
   def initialize(key_input)
     @key_input = key_input
+    @key_length = 7
   end
 
   def validate_key_input
     all_numerical = @key_input.to_s.scan(/\d/).length == @key_input.to_s.length
-    if !all_numerical || @key_input.to_s.length > KEY_LENGTH
-      raise "Key input should be numerical and #{KEY_LENGTH} digits at most."
-      # TO DO: throw error (should be numerical & less than KEY_LENGTH digits)
+    if !all_numerical || @key_input.to_s.length > @key_length
+      raise "Key input should be numerical and #{@key_length} digits at most."
     else
-      format = '%' + '5' + 's'
-      # format = '%' + KEY_LENGTH.to_s + 's'
-      # TO DO: ^ uncomment & deal with fallout from this change -- may need KEY_LENGTH constant (should pull from subclass not ShiftGenerator itself)
+      # format = '%' + '5' + 's'
+      format = '%' + @key_length.to_s + 's'
+      # TO DO: ^ uncomment & deal with fallout from this change -- may need @key_length constant (should pull from subclass not ShiftGenerator itself)
       @formatted_key = (format % @key_input.to_s).gsub(" ", "0")
     end
   end

--- a/lib/shift_generator.rb
+++ b/lib/shift_generator.rb
@@ -2,22 +2,22 @@ class ShiftGenerator
   SHIFT_COUNT = 4
   KEY_LENGTH = 7
 
-  attr_reader :key
+  attr_reader :key_input, :formatted_key
 
   def initialize(key_input)
-    @key = validate_key_input(key_input)
+    @key_input = key_input
   end
 
-  def validate_key_input(key_input)
-    all_numerical = key_input.to_s.scan(/\d/).length == key_input.to_s.length
-    if !all_numerical || key_input.to_s.length > KEY_LENGTH
+  def validate_key_input
+    all_numerical = @key_input.to_s.scan(/\d/).length == @key_input.to_s.length
+    if !all_numerical || @key_input.to_s.length > KEY_LENGTH
       raise "Key input should be numerical and #{KEY_LENGTH} digits at most."
       # TO DO: throw error (should be numerical & less than KEY_LENGTH digits)
     else
       format = '%' + '5' + 's'
       # format = '%' + KEY_LENGTH.to_s + 's'
       # TO DO: ^ uncomment & deal with fallout from this change -- may need KEY_LENGTH constant (should pull from subclass not ShiftGenerator itself)
-      (format % key_input.to_s).gsub(" ", "0")
+      @formatted_key = (format % @key_input.to_s).gsub(" ", "0")
     end
   end
 

--- a/lib/shift_generator.rb
+++ b/lib/shift_generator.rb
@@ -13,9 +13,7 @@ class ShiftGenerator
     if !all_numerical || @key_input.to_s.length > @key_length
       raise "Key input should be numerical and #{@key_length} digits at most."
     else
-      # format = '%' + '5' + 's'
       format = '%' + @key_length.to_s + 's'
-      # TO DO: ^ uncomment & deal with fallout from this change -- may need @key_length constant (should pull from subclass not ShiftGenerator itself)
       @formatted_key = (format % @key_input.to_s).gsub(" ", "0")
     end
   end

--- a/lib/shift_generator.rb
+++ b/lib/shift_generator.rb
@@ -13,9 +13,12 @@ class ShiftGenerator
     if !all_numerical || @key_input.to_s.length > @key_length
       raise "Key input should be numerical and #{@key_length} digits at most."
     else
-      format = '%' + @key_length.to_s + 's'
       @formatted_key = (format % @key_input.to_s).gsub(" ", "0")
     end
+  end
+
+  def format
+    '%' + @key_length.to_s + 's'
   end
 
   def neg_shift_array

--- a/test/date_shift_generator_test.rb
+++ b/test/date_shift_generator_test.rb
@@ -9,33 +9,41 @@ class DateShiftGeneratorTest < Minitest::Test
     assert_instance_of DateShiftGenerator, @date_shift_gen1
   end
 
-  def test_it_has_a_key_length_constant
-    assert_equal 6, DateShiftGenerator::KEY_LENGTH
+  def test_it_inits_with_a_key_input
+    assert_equal "011218", @date_shift_gen1.key_input
+
+    invalid_input = DateShiftGenerator.new("9999999999")
+    assert_equal "9999999999", invalid_input.key_input
   end
 
-  def test_init_adds_padding_to_key_input
-    skip
-    # TO DO: fix ShiftGenerator#validate_key_input so it pads to KEY_LENGTH instead of hard-entered 5
-    assert_equal "011419", DateShiftGenerator.new(11419).key
-    assert_equal "011419", DateShiftGenerator.new("11419").key
+  def test_it_has_a_key_length_of_6
+    assert_equal 6, @date_shift_gen1.key_length
   end
 
-  def test_init_throws_error_if_key_input_too_long_or_non_numerical
-    # TO DO: test a 7 digit input after fixing KEY_LENGTH issue
-    skip
+  def test_it_inits_with_no_formatted_key
+    assert_nil @date_shift_gen1.formatted_key
+  end
+
+  def test_validate_key_input_adds_padding_to_key_input
+    integer_input = DateShiftGenerator.new(11419)
+    assert_equal "011419", integer_input.validate_key_input
+    assert_equal "011419", integer_input.formatted_key
+
+    string_input = DateShiftGenerator.new("11419")
+    assert_equal "011419", string_input.validate_key_input
+    assert_equal "011419", string_input.formatted_key
+  end
+
+  def test_validate_key_input_throws_error_if_key_input_too_long_or_non_numerical
     error_message = "Key input should be numerical and 6 digits at most."
     err1 = assert_raises(RuntimeError) do
-      DateShiftGenerator.new("12042019").key
+      DateShiftGenerator.new("12042019").validate_key_input
     end
     assert_equal error_message, err1.message
     err2 = assert_raises(RuntimeError) do
-      DateShiftGenerator.new("apr11").key
+      DateShiftGenerator.new("apr11").validate_key_input
     end
     assert_equal error_message, err2.message
-  end
-
-  def test_it_inits_with_a_date_key_string
-    assert_equal "011218", @date_shift_gen1.key
   end
 
   def test_shift_array_returns_array_of_abcd_offsets

--- a/test/key_shift_generator_test.rb
+++ b/test/key_shift_generator_test.rb
@@ -21,7 +21,7 @@ class KeyShiftGeneratorTest < Minitest::Test
     assert_nil @key_shift_gen1.formatted_key
   end
 
-  def test_init_adds_padding_to_key_input
+  def test_validate_key_input_adds_padding_to_key_input
     integer_input = KeyShiftGenerator.new(476)
     assert_equal "00476", integer_input.validate_key_input
     assert_equal "00476", integer_input.formatted_key
@@ -31,7 +31,7 @@ class KeyShiftGeneratorTest < Minitest::Test
     assert_equal "00476", string_input.formatted_key
   end
 
-  def test_init_throws_error_if_key_input_too_long_or_non_numerical
+  def test_validate_key_input_throws_error_if_key_input_too_long_or_nonnumerical
     error_message = "Key input should be numerical and 5 digits at most."
     err1 = assert_raises(RuntimeError) do
       KeyShiftGenerator.new("548138").validate_key_input
@@ -43,7 +43,7 @@ class KeyShiftGeneratorTest < Minitest::Test
     assert_equal error_message, err2.message
   end
 
-  def test_key_is_a_string_with_leading_zeroes_even_if_fed_integer
+  def test_formatted_key_is_a_string_with_leading_zeroes_even_if_fed_integer
     key_shift_gen4 = KeyShiftGenerator.new(705)
     assert_equal "00705", key_shift_gen4.validate_key_input
     assert_equal "00705", key_shift_gen4.formatted_key

--- a/test/key_shift_generator_test.rb
+++ b/test/key_shift_generator_test.rb
@@ -9,36 +9,44 @@ class KeyShiftGeneratorTest < Minitest::Test
     assert_instance_of KeyShiftGenerator, @key_shift_gen1
   end
 
-  def test_it_inits_with_a_key
-    assert_equal "58467", @key_shift_gen1.key
+  def test_it_inits_with_a_key_input
+    assert_equal "58467", @key_shift_gen1.key_input
   end
 
-  def test_it_has_a_key_length_constant
-    assert_equal 5, KeyShiftGenerator::KEY_LENGTH
+  def test_it_has_a_key_length_of_5
+    assert_equal 5, @key_shift_gen1.key_length
+  end
+
+  def test_it_inits_with_no_formatted_key
+    assert_nil @key_shift_gen1.formatted_key
   end
 
   def test_init_adds_padding_to_key_input
-    assert_equal "00476", KeyShiftGenerator.new(476).key
-    assert_equal "00476", KeyShiftGenerator.new("476").key
+    integer_input = KeyShiftGenerator.new(476)
+    assert_equal "00476", integer_input.validate_key_input
+    assert_equal "00476", integer_input.formatted_key
+
+    string_input = KeyShiftGenerator.new(476)
+    assert_equal "00476", string_input.validate_key_input
+    assert_equal "00476", string_input.formatted_key
   end
 
   def test_init_throws_error_if_key_input_too_long_or_non_numerical
-    # TO DO: test a 7 digit input after fixing KEY_LENGTH issue
-    skip
     error_message = "Key input should be numerical and 5 digits at most."
     err1 = assert_raises(RuntimeError) do
-      KeyShiftGenerator.new("478884546").key
+      KeyShiftGenerator.new("548138").validate_key_input
     end
     assert_equal error_message, err1.message
     err2 = assert_raises(RuntimeError) do
-      KeyShiftGenerator.new("hi7").key
+      KeyShiftGenerator.new("hi7").validate_key_input
     end
     assert_equal error_message, err2.message
   end
 
   def test_key_is_a_string_with_leading_zeroes_even_if_fed_integer
     key_shift_gen4 = KeyShiftGenerator.new(705)
-    assert_equal "00705", key_shift_gen4.key
+    assert_equal "00705", key_shift_gen4.validate_key_input
+    assert_equal "00705", key_shift_gen4.formatted_key
   end
 
   def test_shift_array_returns_array_of_abcd_keys

--- a/test/shift_generator_test.rb
+++ b/test/shift_generator_test.rb
@@ -29,11 +29,11 @@ class ShiftGeneratorTest < Minitest::Test
   def test_validate_key_input_throws_error_if_key_input_too_long_or_nonnumerical
     error_message = "Key input should be numerical and 7 digits at most."
     err1 = assert_raises(RuntimeError) do
-      KeyShiftGenerator.new("478884546").validate_key_input
+      ShiftGenerator.new("478884546").validate_key_input
     end
     assert_equal error_message, err1.message
     err2 = assert_raises(RuntimeError) do
-      KeyShiftGenerator.new("hi7").validate_key_input
+      ShiftGenerator.new("hi7").validate_key_input
     end
     assert_equal error_message, err2.message
   end

--- a/test/shift_generator_test.rb
+++ b/test/shift_generator_test.rb
@@ -13,8 +13,8 @@ class ShiftGeneratorTest < Minitest::Test
     assert_equal 4, ShiftGenerator::SHIFT_COUNT
   end
 
-  def test_it_has_dummy_key_length_const_equal_to_seven
-    assert_equal 7, ShiftGenerator::KEY_LENGTH
+  def test_it_has_dummy_key_length_attr_equal_to_seven
+    assert_equal 7, @shift_gen1.key_length
   end
 
   def test_it_has_key_input_upon_init

--- a/test/shift_generator_test.rb
+++ b/test/shift_generator_test.rb
@@ -16,4 +16,25 @@ class ShiftGeneratorTest < Minitest::Test
   def test_it_has_dummy_key_length_const_equal_to_seven
     assert_equal 7, ShiftGenerator::KEY_LENGTH
   end
+
+  def test_it_has_key_input_upon_init
+    assert_equal 42, @shift_gen1.key_input
+  end
+
+  def test_validate_key_input_returns_padded_key_if_valid
+    assert_equal "0000042", @shift_gen1.validate_key_input
+    assert_equal "0000042", @shift_gen1.formatted_key
+  end
+
+  def test_validate_key_input_throws_error_if_key_input_too_long_or_nonnumerical
+    error_message = "Key input should be numerical and 7 digits at most."
+    err1 = assert_raises(RuntimeError) do
+      KeyShiftGenerator.new("478884546").validate_key_input
+    end
+    assert_equal error_message, err1.message
+    err2 = assert_raises(RuntimeError) do
+      KeyShiftGenerator.new("hi7").validate_key_input
+    end
+    assert_equal error_message, err2.message
+  end
 end


### PR DESCRIPTION
This PR/branch...
 - Refactors init of `ShiftGenerator` & its children. Instead of running `validate_key_input` from init, just store the `key_input`. Change `KEY_LENGTH` constant to `key_length` initialized attribute -- different for `ShiftGenerator` & each of its children -- polymorphism.
 - Changes the way padded number formats are generated (dependent on key_length)